### PR TITLE
Remove definitions of ambiguous methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [compat]
-BitFlags = "0.1"
+BitFlags = "0.1.7"
 MacroTools = "0.5"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnixMmap"
 uuid = "674b2976-56af-439b-a2b1-837be4a3d087"
 authors = ["Justin Willmert <justin@willmert.me> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"

--- a/src/consts.jl
+++ b/src/consts.jl
@@ -7,14 +7,12 @@ import .Sys # explicitly imported to allow docs generation to override
     PROT_WRITE = 0x02
     PROT_EXEC  = 0x04
 end
-Base.cconvert(::Type{T}, pf::MmapProtection) where {T <: Integer} = T(pf)
 
 @bitflag SyncFlags::Cuint begin
     MS_ASYNC      = 0x1
     MS_INVALIDATE = 0x2
     MS_SYNC       = 0x4
 end
-Base.cconvert(::Type{T}, sf::SyncFlags) where {T <: Integer} = T(sf)
 
 @staticexpand @bitflag MmapFlags::Cuint begin
     MAP_FILE      = 0x00
@@ -67,7 +65,6 @@ Base.cconvert(::Type{T}, sf::SyncFlags) where {T <: Integer} = T(sf)
         MAP_STACK    = 0x2000
     end
 end
-Base.cconvert(::Type{T}, mf::MmapFlags) where {T <: Integer} = T(mf)
 
 # Provide this weird mode?
 #@static if Sys.islinux()
@@ -116,7 +113,6 @@ Base.cconvert(::Type{T}, mf::MmapFlags) where {T <: Integer} = T(mf)
         MADV_FREE = 6
     end
 end
-Base.cconvert(::Type{T}, af::AdviseFlags) where {T <: Integer} = T(af)
 
 # documentation requires the types to be defined first, so do after the fact
 let _flag_docs

--- a/src/mmap.jl
+++ b/src/mmap.jl
@@ -47,6 +47,8 @@ function _sys_mmap(ptr::Ptr{Cvoid}, len::Int,
             ArgumentError("requested size must be < $(typemax(Int)-PAGESIZE), got $len"))
     offset >= 0 || throw(ArgumentError("requested offset must be ≥ 0, got $offset"))
 
+    # N.B. mmap may be a C header macro to another name, so use Julia's wrapper (just as
+    #      Mmap.mmap does)
     ret = ccall(:jl_mmap, Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t, Cint, Cint, RawFD, Int64),
                 ptr, len, prot, flags, fd, offset)
     Base.systemerror("mmap", reinterpret(Int, ret) == -1)


### PR DESCRIPTION
These are generated by BitFlags since it's first public release, and
adding these methods then makes the methods all ambiguous.
    
(Best guess is that the methods have been a long hold-over since a time
when BitFlags hadn't been fully fleshed out yet.)

Include a bump to requiring BitFlags v0.1.7 which added tests and fixes
for ccall conversions.