### PR TITLE
Set finalizer on underlying `Memory` object in Julia 1.11+

### DIFF
--- a/src/mmap.jl
+++ b/src/mmap.jl
@@ -80,7 +80,8 @@ function _mmap(::Type{Array{T}}, dims::NTuple{N,Integer},
     ptr = _sys_mmap(C_NULL, mmaplen, prot, flags, fd, Int64(offset) - page_pad)
     aptr = convert(Ptr{T}, ptr + page_pad)
     array = unsafe_wrap(Array{T,N}, aptr, dims)
-    finalizer(_ -> _sys_unmap!(ptr, mmaplen), array)
+    finalizer(_ -> _sys_unmap!(ptr, mmaplen),
+              @static VERSION >= v"1.11.0-DEV" && hasfield(Array, :ref) ? array.ref.mem : array)
     return array
 end
 function _mmap(::Type{Array{T}}, len::Int, prot::MmapProtection, flags::MmapFlags,


### PR DESCRIPTION
In Julia 1.11+ with the new `Memory` object, the memory is not actually owned by the constructed `Array` and therefore the finalizer may trigger too early when the underlying memory is transfered from an `Array` to a different kind of owner (such as `IOBuffer`).

Fix this by conditionally checking for the Julia 1.11+ behavior, and instead setting the finalizer on the `Memory`, if necessary.

Duplicates the improvement made to the Mmap stdlib's implementation: JuliaLang/julia#54210